### PR TITLE
docs: 🌐 update snippets and readme for NukeLexicon 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
   <br>
 
   <p>
+    <a href="https://discord.nukecraft5419.com/">
+      <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/social/discord-plural_vector.svg" alt="discord-plural" height="64" style="margin-right: 5px;" />
+    </a>
+    <a href="https://x.com/Nukecraft5419">
+      <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/social/twitter-singular_vector.svg" alt="twitter-singular" height="64" style="margin-right: 5px;" />
+    </a>
     <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/built-with/java_vector.svg" alt="Java" height="64" style="margin-right: 5px;" />
     <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/cozy/built-with/gradle_vector.svg" alt="Gradle" height="64" style="margin-right: 5px;" />
   </p>

--- a/index.html
+++ b/index.html
@@ -244,9 +244,9 @@
      * Repository dependency snippets
      */
     const snippets = {
-        kts: `repositories {\n    mavenCentral()\n    maven("https://repo.nukecraft5419.com/")\n}\n\ndependencies {\n    implementation("dev.nukecraft5419:nukelexicon:1.0.0")\n}`,
-        groovy: `repositories {\n    mavenCentral()\n    maven { url 'https://repo.nukecraft5419.com/' }\n}\n\ndependencies {\n    implementation 'dev.nukecraft5419:nukelexicon:1.0.0'\n}`,
-        maven: `<repository>\n    <id>nukecraft5419-repo</id>\n    <url>https://repo.nukecraft5419.com/</url>\n</repository>\n\n<dependency>\n    <groupId>dev.nukecraft5419</groupId>\n    <artifactId>nukelexicon</artifactId>\n    <version>1.0.0</version>\n</dependency>`
+        kts: `repositories {\n    mavenCentral()\n    maven("https://repo.nukecraft5419.com/")\n}\n\ndependencies {\n    implementation("dev.nukecraft5419:nukelexicon:1.1.0")\n}`,
+        groovy: `repositories {\n    mavenCentral()\n    maven { url 'https://repo.nukecraft5419.com/' }\n}\n\ndependencies {\n    implementation 'dev.nukecraft5419:nukelexicon:1.1.0'\n}`,
+        maven: `<repository>\n    <id>nukecraft5419-repo</id>\n    <url>https://repo.nukecraft5419.com/</url>\n</repository>\n\n<dependency>\n    <groupId>dev.nukecraft5419</groupId>\n    <artifactId>nukelexicon</artifactId>\n    <version>1.1.0</version>\n</dependency>`
     };
 
     /**


### PR DESCRIPTION
## 📦 Summary
This PR updates the repository and the landing page to reflect the new release of **NukeLexicon 1.1.0**.

## ✨ Changes
* Updated `index.html` with the new dependency snippets (Gradle/Maven) pointing to version `1.1.0`.
* Updated `README.md` to show the latest stable version and release notes link.

## ✅ Resolved Issues
Closes #1, Closes #2